### PR TITLE
jar: Restrict visibility of entries within JarEntries

### DIFF
--- a/src/main/kotlin/com/open592/appletviewer/jar/JarEntries.kt
+++ b/src/main/kotlin/com/open592/appletviewer/jar/JarEntries.kt
@@ -6,7 +6,16 @@ import okio.Buffer
  * A simple wrapper around jar entries, provide some helper
  * methods to extract their content.
  */
-public data class JarEntries(public val entries: Map<String, Buffer>) {
+public data class JarEntries(private val entries: Map<String, Buffer>) {
+    /**
+     * Return the entry with the given name
+     *
+     * @param name Name of the extension to retrieve
+     */
+    public fun getEntry(name: String): Buffer? {
+        return entries[name]
+    }
+
     /**
      * Return the first entry with the provided file extension.
      *

--- a/src/test/kotlin/com/open592/appletviewer/jar/SignedJarFileResolverTest.kt
+++ b/src/test/kotlin/com/open592/appletviewer/jar/SignedJarFileResolverTest.kt
@@ -51,8 +51,7 @@ class SignedJarFileResolverTest {
         resolveFileResource("unsigned-jar.jar").use { file ->
             val jarEntries = resolver.resolveEntries(file)
 
-            assertEquals(jarEntries.entries.size, 1)
-            assertEquals(EXPECTED_TEST_JAR_ENTRY_CONTENTS, jarEntries.entries[TEST_JAR_ENTRY_NAME]?.readUtf8Line())
+            assertEquals(EXPECTED_TEST_JAR_ENTRY_CONTENTS, jarEntries.getEntry(TEST_JAR_ENTRY_NAME)?.readUtf8Line())
         }
     }
 
@@ -70,12 +69,9 @@ class SignedJarFileResolverTest {
         resolveFileResource("valid-official-jagex-loader.jar").use { file ->
             val jarEntries = resolver.resolveEntries(file)
 
-            // The official 592 loader jar contains 15 entries
-            assertEquals(jarEntries.entries.size, 15)
-
             // Test for presence of some known entries
-            assertNotNull(jarEntries.entries["loader.class"])
-            assertNotNull(jarEntries.entries["unpack.class"])
+            assertNotNull(jarEntries.getEntry("loader.class"))
+            assertNotNull(jarEntries.getEntry("unpack.class"))
         }
     }
 
@@ -109,8 +105,7 @@ class SignedJarFileResolverTest {
         resolveFileResource("valid-open592-test-jar.jar").use { file ->
             val jarEntries = resolver.resolveEntries(file)
 
-            assertEquals(1, jarEntries.entries.size)
-            assertEquals(EXPECTED_TEST_JAR_ENTRY_CONTENTS, jarEntries.entries[TEST_JAR_ENTRY_NAME]?.readUtf8Line())
+            assertEquals(EXPECTED_TEST_JAR_ENTRY_CONTENTS, jarEntries.getEntry(TEST_JAR_ENTRY_NAME)?.readUtf8Line())
         }
     }
 


### PR DESCRIPTION
No need to expose underlying `Map`, makes more sense to expose a function which directly returns the `Buffer?`

Might make sense to add some more test cases which cover the logic which was removed, but I can't think of anything right now.