### PR TITLE
dependencies: Fix bug in progress reporting

### DIFF
--- a/src/main/kotlin/com/open592/appletviewer/dependencies/RemoteDependencyFetcher.kt
+++ b/src/main/kotlin/com/open592/appletviewer/dependencies/RemoteDependencyFetcher.kt
@@ -44,17 +44,23 @@ public class RemoteDependencyFetcher @Inject constructor(
                         }
 
                         val totalDownloadSize = getTotalDownloadSize()
-                        do {
+                        var bytesRead: Long
+
+                        while (true) {
                             // In case we can't resolve the content length from the server use the default
                             // specified within the original applet viewer
-                            val bytesRead = source.read(buffer, contentLength ?: 300_000)
+                            bytesRead = source.read(buffer, contentLength ?: 300_000)
+
+                            if (bytesRead == -1L) {
+                                break
+                            }
 
                             totalDownloadedBytes += bytesRead.toInt()
 
                             val progress = ((100.0 * totalDownloadedBytes) / totalDownloadSize).toInt()
 
                             eventBus.dispatch(ProgressEvent.UpdateProgress(progress))
-                        } while (bytesRead != -1L)
+                        }
 
                         return buffer
                     }


### PR DESCRIPTION
When calculating the progress we weren't breaking out of the buffer read loop when we encountered the end of the buffer. Since read() returns -1 when it encounters the end of the buffer we were removing a byte from `totalDownloadedBytes` and thus reporting 99% progress even after fully downloading all remote dependencies.