### PR TITLE
dependencies: Simplify dependency resolver base class

### DIFF
--- a/src/main/kotlin/com/open592/appletviewer/dependencies/BrowserControlResolver.kt
+++ b/src/main/kotlin/com/open592/appletviewer/dependencies/BrowserControlResolver.kt
@@ -19,7 +19,6 @@ public class BrowserControlResolver @Inject constructor(
     environment: Environment,
 ) : RemoteDependencyResolver(
     configuration = configuration,
-    type = DependencyType.BROWSERCONTROL,
 ) {
     /**
      * The extension of the resulting library file on the filesystem.
@@ -82,8 +81,10 @@ public class BrowserControlResolver @Inject constructor(
     public override fun resolve() {
         val libraryFilename = getLibraryFilename()
 
-        val jarFile = dependencyFetcher.fetchRemoteDependency(type, getUrl(getRemoteFileConfigKey()))
-            ?: throw ResolveException(configuration.getContent("err_load_bc"))
+        val jarFile = dependencyFetcher.fetchRemoteDependency(
+            DependencyType.BROWSERCONTROL,
+            getUrl(getRemoteFileConfigKey()),
+        ) ?: throw ResolveException(configuration.getContent("err_load_bc"))
 
         val jarEntries = signedJarFileResolver.resolveEntries(jarFile)
 

--- a/src/main/kotlin/com/open592/appletviewer/dependencies/LoaderResolver.kt
+++ b/src/main/kotlin/com/open592/appletviewer/dependencies/LoaderResolver.kt
@@ -8,10 +8,10 @@ public class LoaderResolver @Inject constructor(
     private val dependencyFetcher: RemoteDependencyFetcher,
     private val configuration: ApplicationConfiguration,
     private val inMemoryClassLoaderFactory: InMemoryClassLoaderFactory,
-) : RemoteDependencyResolver(configuration, type = DependencyType.LOADER) {
+) : RemoteDependencyResolver(configuration) {
     override fun resolve() {
         val jarFile = dependencyFetcher.fetchRemoteDependency(
-            type = DependencyType.LOADER,
+            DependencyType.LOADER,
             getUrl(URL_CONFIG_KEY),
         ) ?: throw ResolveException(configuration.getContent(RESOLVE_LOADER_ERROR_KEY))
         val inMemoryClassLoader = inMemoryClassLoaderFactory.create(jarFile)

--- a/src/main/kotlin/com/open592/appletviewer/dependencies/RemoteDependencyResolver.kt
+++ b/src/main/kotlin/com/open592/appletviewer/dependencies/RemoteDependencyResolver.kt
@@ -4,7 +4,6 @@ import com.open592.appletviewer.config.ApplicationConfiguration
 
 public abstract class RemoteDependencyResolver(
     private val configuration: ApplicationConfiguration,
-    public val type: DependencyType,
 ) {
     public abstract fun resolve()
 


### PR DESCRIPTION
No need for this to be a dependency, just reference it directly in the parent.